### PR TITLE
Filter out empty keywords before sorting. [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Filter out empty keywords before sorting.
+  Otherwise the control panel is broken for some indexes.
+  Fixes `issue #28 <https://github.com/collective/Products.PloneKeywordManager/issues/28>`_.
+  [maurits]
 
 
 3.0.0 (2019-03-14)

--- a/src/Products/PloneKeywordManager/tool.py
+++ b/src/Products/PloneKeywordManager/tool.py
@@ -147,6 +147,8 @@ class PloneKeywordManager(UniqueObject, SimpleItem):
 
         catalog = getToolByName(self, "portal_catalog")
         keywords = catalog.uniqueValuesFor(indexName)
+        # Filter out empty keywords.  The sorting breaks when None is indexed.
+        keywords = filter(None, keywords)
         return list(sorted(keywords, key=lambda x: x.lower()))
 
     @security.protected(config.MANAGE_KEYWORDS_PERMISSION)


### PR DESCRIPTION
Otherwise the control panel is broken for some indexes.

Fixes issue #28.