### PR TITLE
Fixed coverage setup. [master]

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+include =
+    src/Products/PloneKeywordManager/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,13 @@
 .installed.cfg
 .mr.developer.cfg
 .python-version
-.coveragerc
+.coverage
 bin/
 coverage/
 develop-eggs/
 downloads/
 eggs/
+htmlcov/
 include/
 lib/
 library-settings.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,7 @@ script:
   - if [ ${pyversion:7:1} = 3 ]; then black --check; else echo "Skip black check"; fi
   - bin/test --all
 
-after_script:
-  - bin/createcoverage --output-dir=parts/test/coverage
-
 after_success:
+  - bin/createcoverage --output-dir=parts/test/coverage
   - pip install -q coveralls
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,5 @@ after_script:
   - bin/createcoverage --output-dir=parts/test/coverage
 
 after_success:
-  - pip install coverage
-  - python -m coverage.pickle2json
   - pip install -q coveralls
   - coveralls


### PR DESCRIPTION
- There was no `.coveragerc` to restrict the files to check.  In fact, it was in the .gitignore file.
- Travis pip installed `coverage`, which was already there.
- Travis used `coverage.pickle2json` to convert the `.coverage` file from v3 to v4, but we were already using v4, so that broke.

Travis also gave an error:

```
ERROR: Something went wrong when executing '/home/travis/build/collective/Products.PloneKeywordManager/bin/coverage html --directory=parts/test/coverage'
ERROR: Returncode: 1
ERROR: Output:
ERROR: No source for code: '/home/travis/build/collective/Products.PloneKeywordManager/parts/test/18751b0da9dbd048c270e84ef48a19d2.py'.
Aborting report output, consider using -i.
```

Result was that coverall reported that coverage remained the same at '?%'
https://coveralls.io/builds/23424458