### PR TITLE
Consistently handle reindexing Comments on AT and DX objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
+- Ensure plone.app.discussion comments with acquired keywords are
+  consistently reindexed.
+  [alecpm]
+
 - Fix toggle to work with Chameleon.
   Fixes `issue #33 <https://github.com/collective/Products.PloneKeywordManager/issues/33>`_.
   [petschki]

--- a/src/Products/PloneKeywordManager/tool.py
+++ b/src/Products/PloneKeywordManager/tool.py
@@ -239,13 +239,13 @@ class PloneKeywordManager(UniqueObject, SimpleItem):
             fieldName = fieldName[0].lower() + fieldName[1:]
             return lambda value: setattr(aq_base(obj), fieldName, value)
 
-        # AT and discussions left
+        # Always reindex discussion objects, since their values
+        # # will have been acquired
         if IComment.providedBy(obj):
-            # Discussion
-            field = getattr(obj, "getField", None)
-        else:
-            # Archetype
-            field = getattr(aq_base(obj), "getField", None)
+            return lambda value: None
+
+        # Anything left is maybe AT content
+        field = getattr(aq_base(obj), "getField", None)
         # Archetypes:
         if field:
             fieldObj = field(fieldName) or field(fieldName.lower())


### PR DESCRIPTION
The existing implementation assumes that Comments are children of AT content and have access to the parent's `getField` method. To handle Comments on both AT and DX content, this change returns a no-op mutator for all `IComment` objects. That should ensure that they are always reindexed when they match the query and any acquired values are reindexed.

The prior implementation used the parent's AT mutator to ensure the ordering in which the Comment and its Parent were mutated/indexed didn't matter. This implementation ignores the parent mutator and relies implicitly on the deferred indexing from collective.indexing to handle such ordering concerns.