### PR TITLE
Issue 17

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+3.0.4?  issue-17 branch (unmerged)
+-----------------
+* Improvements to form performance when site has an extreme amount of keywords. [flipmcf]
+  -- Implemented use of CMFPlone.PloneBatch for result set.
+  -- Removed the "View range" form as that should be handled by plone batching now.
+
+- Removed direct calls to PloneKeywordManager tool from template (best practice)  [flipmcf] 
+    template must go through view for everything.
+    
+- Renaming variables in template from 'subject' to 'keyword' - better reflects the option to view different fields. [flipmcf]
+
 3.0.4 (unreleased)
 ------------------
 

--- a/src/Products/PloneKeywordManager/browser/configure.zcml
+++ b/src/Products/PloneKeywordManager/browser/configure.zcml
@@ -17,4 +17,12 @@
       layer=".interfaces.IPloneKeywordManagerLayer"
       />
 
+  <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="keywordsmanager-search-json"
+      class=".prefs_keywords_view.KeywordsSearchResults"
+      permission="plone_keyword_manager.UsePloneKeywordManager"
+      layer=".interfaces.IPloneKeywordManagerLayer"
+  />
+
 </configure>

--- a/src/Products/PloneKeywordManager/browser/prefs_keywords_view.pt
+++ b/src/Products/PloneKeywordManager/browser/prefs_keywords_view.pt
@@ -18,7 +18,8 @@
                  many_kws python: 20;
                  pkm    context/portal_keyword_manager;
                  catalogSubjects python:pkm.getKeywords(context=context,indexName=field);
-                 show_filters python: len(catalogSubjects) > many_kws;
+                 too_many_keywords python: len(catalogSubjects) > many_kws;
+                 show_filters too_many_keywords;
                  url_quote python:modules['Products.PythonScripts.standard'].url_quote">
 
   <!-- catalogSubjects  -->
@@ -160,6 +161,11 @@
 
       </fieldset>
     </form>
+
+    <div tal:condition="too_many_keywords">
+    Too many keywords to show (<span tal:content="python: len(catalogSubjects)"> </span>)
+    Select a above range or search to show some keywords
+    </div>
 
     <form name="keyword_edit_form" action="." method="post"
           tal:condition="python:not show_filters or search or limit"

--- a/src/Products/PloneKeywordManager/browser/prefs_keywords_view.pt
+++ b/src/Products/PloneKeywordManager/browser/prefs_keywords_view.pt
@@ -13,16 +13,16 @@
                  search python:request.get('search', '');
                  limit  python:request.get('limit',  '');
                  score  python:request.get('score',  0.6);
-                 num    python:request.get('num',7);
+                 num_similar    python:request.get('num_similar',7);
                  field  python:request.get('field','Subject');
-                 many_kws python: 20;
-                 pkm    context/portal_keyword_manager;
-                 catalogSubjects python:pkm.getKeywords(context=context,indexName=field);
-                 too_many_keywords python: len(catalogSubjects) > many_kws;
-                 show_filters too_many_keywords;
-                 url_quote python:modules['Products.PythonScripts.standard'].url_quote">
 
-  <!-- catalogSubjects  -->
+                 batch_start python:request.get('b_start',0);
+                 batch_size python:request.get('b_size', 30);
+                 batch python:view.getKeywords(indexName=field, b_start=batch_start, b_size=batch_size);
+
+                 total_keywords python:batch.sequence_length;
+
+                 url_quote python:modules['Products.PythonScripts.standard'].url_quote">
 
   <h1 i18n:translate="heading_keyword_manager">Keyword Manager</h1>
 
@@ -39,7 +39,7 @@
     The Keyword Manager allows you to delete and merge keywords in your portal.
     </div>
 
-      <tal:kw_fields tal:define="kwfields pkm/getKeywordIndexes"
+      <tal:kw_fields tal:define="kwfields python:view.getKeywordIndexes()"
                      tal:condition="python:len(kwfields)>1">
         <form action="prefs_keywords_view" method="get"
               tal:attributes="action string:${context/absolute_url}/prefs_keywords_view">
@@ -84,50 +84,10 @@
           </div>
       </fieldset>
 
-  <tal:site_has_keywords condition="python:len(catalogSubjects) > 0">
-    <form action="prefs_keywords_view" method="get"
-          tal:attributes="action string:${context/absolute_url}/prefs_keywords_view"
-          tal:condition="show_filters">
-        <input type="hidden" name="field" tal:attributes="value field" />
-        <fieldset>
-        <legend i18n:translate="label_list_alphabetically">
-              List alphabetically
-        </legend>
-
-        <div class="field">
-            <label for="select_alphabet_list"
-                   i18n:translate="label_view_range">
-                  View range
-            </label>
-
-            <select id="select_alphabet_list"
-                    name="limit" tabindex="1"
-                    onchange="javascript:this.form.submit()">
-
-                <option value="a-z">a - z</option>
-
-                <tal:block tal:repeat="item python:range(ord('a'),ord('z')+1)">
-                    <option value="a" tal:attributes="value python:chr(item);
-                                                      selected python:limit==chr(item) and True or None"
-                            tal:content="python:chr(item)">a</option>
-                </tal:block>
-
-            </select>
-        </div>
-
-        <div class="formControls">
-            <input class="standalone"
-                   type="submit"
-                   value="View keywords"
-                   i18n:attributes="value" />
-        </div>
-
-      </fieldset>
-    </form>
+  <tal:site_has_keywords condition="total_keywords">
 
     <form action="prefs_keywords_view"
           tal:attributes="action string:${context/absolute_url}/prefs_keywords_view"
-          tal:condition="show_filters"
           class="pat-livesearch"
           data-pat-livesearch="ajaxUrl:${context/absolute_url}/keywordsmanager-search-json">
       <input type="hidden" name="field" tal:attributes="value field" />
@@ -162,13 +122,7 @@
       </fieldset>
     </form>
 
-    <div tal:condition="too_many_keywords">
-    Too many keywords to show (<span tal:content="python: len(catalogSubjects)"> </span>)
-    Select a above range or search to show some keywords
-    </div>
-
     <form name="keyword_edit_form" action="." method="post"
-          tal:condition="python:not show_filters or search or limit"
           tal:attributes="action string:${context/absolute_url}/prefs_keywords_view"
           >
                         <input type="hidden" name="form.submitted" value="1" />
@@ -179,47 +133,48 @@
           Keyword assignments
         </legend>
 		<p class="discreet" i18n:translate="help_keyword_assignments">
-		Select one or more keywords, then set a replacement keyword and click on 'Merge / Replace' to replace all selected value by this one. Click on Delete to remove selected values.
+		Select one or more keywords, then either
+		 set a replacement keyword and click on 'Merge / Replace' to replace all selected value by this one.
+		 Click on Delete to remove selected values.
 		</p>
         <div class="field">
-        <dl tal:repeat="subject python:search and [search] or catalogSubjects">
-         <tal:block
-            condition="python:not show_filters or search or limit=='a-z' or (subject and limit==subject.lower()[0])"
-            define="subject_id python:context.plone_utils.normalizeString(subject);
-                    subject_quote python:url_quote(subject)">
+        <dl tal:repeat="keyword python:batch">
+        <tal:def tal:define="keyword_id python:context.plone_utils.normalizeString(keyword);
+                             keyword_quote python:url_quote(keyword)">
          <dt>
           <input type="checkbox" name="keywords:list"
-                 tal:attributes="value subject;
-                                 id string:subject-${subject_id};
-                                 onclick string:document.forms['keyword_edit_form'].changeto.value='${subject}';; return true;;" />
-          <label tal:content="subject" tal:attributes="for string:subject-${subject_id};">Subject</label>
+                 tal:attributes="value keyword;
+                                 id string:keyword-${keyword_id};
+                                 onclick string:document.forms['keyword_edit_form'].changeto.value='${keyword}';; return true;;" />
+          <label tal:content="keyword" tal:attributes="for string:keyword-${keyword_id};">Keyword</label>
           <tal:p5 tal:condition="view/is_plone_5">
-            <a href="#" tal:attributes="href string:${portal_url}/@@search?${field}=${subject_quote}">
+            <a href="#" tal:attributes="href string:${portal_url}/@@search?${field}=${keyword_quote}">
               <span class="icon-search"></span></a>
           </tal:p5>
           <tal:p4 tal:condition="not: view/is_plone_5">
-            <a href="#" tal:attributes="href string:${portal_url}/@@search?${field}=${subject_quote}">
+            <a href="#" tal:attributes="href string:${portal_url}/@@search?${field}=${keyword_quote}">
               <img i18n:attributes="alt"
                    i18n:domain="plone"
                    tal:attributes="src string:${portal_url}/search_icon.png;"
                    alt="Search"/></a>
           </tal:p4>
          </dt>
+
          <dd class="simkeywords" style="display:none;">
-           <span tal:repeat="item python:pkm.getScoredMatches(subject, catalogSubjects, num, score, context=context)" style="white-space: nowrap;">
-             <span tal:condition="python:subject!=item"
+           <span tal:repeat="item python:view.getScoredMatches(keyword, batch, num_similar, score)" style="white-space: nowrap;">
+             <span tal:condition="python:keyword!=item"
                    tal:define="item_id python:context.plone_utils.normalizeString(item)">
               <input type="checkbox" name="keywords:list"
                      tal:attributes="value item;
                                      id string:item-${item_id};
                                      onclick string: document.forms['keyword_edit_form'].changeto.value='${item}';; return true;;" />
-              <label tal:content="item" tal:attributes="for string:item-${item_id};">Subject</label>
+              <label tal:content="item" tal:attributes="for string:item-${item_id};">Keyword</label>
               <tal:p5 tal:condition="view/is_plone_5">
-                <a href="#" tal:attributes="href string:${portal_url}/@@search?${field}=${subject_quote}">
+                <a href="#" tal:attributes="href string:${portal_url}/@@search?${field}=${keyword_quote}">
                   <span class="icon-search"></span></a>
               </tal:p5>
               <tal:p4 tal:condition="not: view/is_plone_5">
-                <a href="#" tal:attributes="href string:${portal_url}/@@search?${field}=${subject_quote}">
+                <a href="#" tal:attributes="href string:${portal_url}/@@search?${field}=${keyword_quote}">
                   <img i18n:attributes="alt"
                        i18n:domain="plone"
                        tal:attributes="src string:${portal_url}/search_icon.png;"
@@ -228,11 +183,12 @@
              </span>
            </span>
          </dd>
-
-         </tal:block>
-
+         </tal:def>
         </dl>
 	  </div>
+	  <tal:batchnavigation
+        define="batchnavigation nocall:context/@@batchnavigation"
+        replace="structure python:batchnavigation(batch)" />
       <div class="field">
                 <div class="error"
                      tal:define="err errors/changeto|nothing"
@@ -269,7 +225,7 @@
     </script>
   </tal:site_has_keywords>
 
-  <tal:no_keywords_yet condition="not:catalogSubjects">
+  <tal:no_keywords_yet condition="not:total_keywords">
     <div i18n:translate="description_no_keywords">
       No content in this site has any keywords assigned yet, so there's nothing
       to manage at this time.  (To assign keywords to a piece of content, use

--- a/src/Products/PloneKeywordManager/browser/prefs_keywords_view.pt
+++ b/src/Products/PloneKeywordManager/browser/prefs_keywords_view.pt
@@ -21,6 +21,8 @@
                  show_filters python: len(catalogSubjects) > many_kws;
                  url_quote python:modules['Products.PythonScripts.standard'].url_quote">
 
+  <!-- catalogSubjects  -->
+
   <h1 i18n:translate="heading_keyword_manager">Keyword Manager</h1>
 
     <a href=""
@@ -124,7 +126,9 @@
 
     <form action="prefs_keywords_view"
           tal:attributes="action string:${context/absolute_url}/prefs_keywords_view"
-          tal:condition="show_filters">
+          tal:condition="show_filters"
+          class="pat-livesearch"
+          data-pat-livesearch="ajaxUrl:${context/absolute_url}/keywordsmanager-search-json">
       <input type="hidden" name="field" tal:attributes="value field" />
       <fieldset>
         <legend i18n:translate="label_search_by_keyword">
@@ -138,14 +142,10 @@
               Keyword
           </label>
 
-          <select id="select_keyword_list" name="search"
-                  onchange="javascript:this.form.submit()">
-            <option value="" i18n:translate="label_select">Select...</option>
-           <tal:block tal:repeat="subject catalogSubjects">
-            <option tal:content="subject"
-                    tal:attributes="selected python:subject==search">Subject</option>
-           </tal:block>
-          </select>
+          <input type="text" autocomplete="off">
+          <ul class="livesearch-results" style="display:none;">
+            <li i18n:translate="label_select">Select...</li>
+          </ul>
 
         </div>
 

--- a/src/Products/PloneKeywordManager/browser/prefs_keywords_view.pt
+++ b/src/Products/PloneKeywordManager/browser/prefs_keywords_view.pt
@@ -142,7 +142,7 @@
               Keyword
           </label>
 
-          <input type="text" autocomplete="off">
+          <input type="text" name="s" autocomplete="off">
           <ul class="livesearch-results" style="display:none;">
             <li i18n:translate="label_select">Select...</li>
           </ul>

--- a/src/Products/PloneKeywordManager/browser/prefs_keywords_view.py
+++ b/src/Products/PloneKeywordManager/browser/prefs_keywords_view.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import json
+
 from plone import api
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
@@ -6,6 +8,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.PloneKeywordManager import keywordmanagerMessageFactory as _
 from Products.PloneKeywordManager.compat import to_str
 from Products.CMFPlone.utils import safe_encode
+
 
 import logging
 
@@ -108,3 +111,11 @@ class PrefsKeywordsView(BrowserView):
             url = "%s?field=%s" % (url, field)
 
         self.request.RESPONSE.redirect(url)
+
+class KeywordsSearchResults(BrowserView):
+
+    def __call__(self):
+        self.request.response.setHeader("Content-type", "application/json")
+
+        result = {'some': 'json'}
+        return json.dumps(result)

--- a/src/Products/PloneKeywordManager/browser/prefs_keywords_view.py
+++ b/src/Products/PloneKeywordManager/browser/prefs_keywords_view.py
@@ -132,13 +132,23 @@ class KeywordsSearchResults(BrowserView):
         field = self.request.form.get('field')
 
         results = self.results(search_string, index_name=field)
+        portal_url = self.context.portal_url()
+
+        for result in results:
+            items.append({'id': result,
+                          'title': result,
+                          'description': '',
+                          'state': "keyword",
+                          'url': "%s/prefs_keywords_view?field=%s&s=%s" % (portal_url, field, search_string),
+                          })
 
         self.request.response.setHeader("Content-type", "application/json")
 
         return json.dumps({
             'total': len(results),
-            'items': results
+            'items': items
         })
+
 
     def results(self, search_string, index_name):
         pkm = getToolByName(self.context, "portal_keyword_manager")

--- a/src/Products/PloneKeywordManager/tool.py
+++ b/src/Products/PloneKeywordManager/tool.py
@@ -140,7 +140,7 @@ class PloneKeywordManager(UniqueObject, SimpleItem):
         return len(querySet)
 
     @security.protected(config.MANAGE_KEYWORDS_PERMISSION)
-    def getKeywords(self, context=None, indexName="Subject"):
+    def getKeywords(self, indexName="Subject"):
         processQueue()
         if indexName not in self.getKeywordIndexes():
             raise ValueError("%s is not a valid field" % indexName)


### PR DESCRIPTION
This is big and I need some eyes.

This PR goes into a new branch - "flipmcf/issue 17"  It's not ready for master yet.  So approval should be easy.

-----
https://github.com/collective/Products.PloneKeywordManager/issues/17

The goal is to make the form respond better when the list of keywords is enormous.

* I have added PloneBatch to the list of keywords
* I have added livesearch to the "Keyword Search" form.

Opinions:
I removed the "select range" form - that functionality is really handled by batching now.
I removed the checks to show / hide the filtering forms based on the number of keywords:
  I see this as 'magic UI'  I'd rather move the filtering forms to somewhere less invasive then hide them based on a variable that's out of the user's control.   Imaging adding just 'one more keyword' and suddenly your user experience changes?

I also removed all calls directly to the KeywordManager Tool from the template.   The view gets a hold of the Tool and the template talks to the view.  Best Practice.

I renamed some variables in the template (specifically 'subject' / 'subjects' to 'keyword' / 'keywords')  I think 'subject / subjects' is an old name for when the form was developed with only the 'subjects' field in mind.  Now that you can select which field to work on,  the more generic 'keyword' should be used as a variable name.


