### PR TITLE
Filter out 'None' values from keywords, not empty strings #45

### DIFF
--- a/src/Products/PloneKeywordManager/tool.py
+++ b/src/Products/PloneKeywordManager/tool.py
@@ -147,8 +147,9 @@ class PloneKeywordManager(UniqueObject, SimpleItem):
 
         catalog = getToolByName(self, "portal_catalog")
         keywords = catalog.uniqueValuesFor(indexName)
-        # Filter out empty keywords.  The sorting breaks when None is indexed.
-        keywords = filter(None, keywords)
+        # Filter out Null keywords.  The sorting breaks when None is indexed.
+        def notNone(x): return x is not None
+        keywords = filter(notNone, keywords)
 
         #can we turn this into a yield?
         return list(sorted(keywords, key=lambda x: x.lower()))


### PR DESCRIPTION
The filtering seems to try to filter out 'None' from the list of keyword values.

It ends up filtering out any keyword that evaluates to False.  (so, empty string, integer 0, etc)

This fixes that issue.