### PR TITLE
Issue 53

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,7 @@ Changelog
    
 
 3.0.4 (unreleased)
-------------------
-- Fix UnicodeDecodeError in portal status message after merging non-ascii keywords.
-  [jensens]
-  
+------------------ 
 - Improvements to form performance when site has an extreme amount of keywords. [flipmcf]
         - Implemented use of CMFPlone.PloneBatch for result set.
   	- Removed the "View range" form as that should be handled by plone batching now.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,7 @@ Changelog
 
 3.0.4 (unreleased)
 ------------------
-
-- Fix UnicodeDecodeError in portal status message after merging non-ascii keywords. 
+- Fix UnicodeDecodeError in portal status message after merging non-ascii keywords.
   [jensens]
   
 - Improvements to form performance when site has an extreme amount of keywords. [flipmcf]
@@ -16,7 +15,6 @@ Changelog
 - Removed direct calls to PloneKeywordManager tool from template (best practice). [flipmcf]
 
 - Filter out only None keyword values, not false values. Fixes `issue #45 <https://github.com/collective/Products.PloneKeywordManager/issues/45>`_. [flipmcf]
-
 
 
 3.0.3 (2021-01-27)

--- a/src/Products/PloneKeywordManager/browser/prefs_keywords_view.pt
+++ b/src/Products/PloneKeywordManager/browser/prefs_keywords_view.pt
@@ -159,7 +159,7 @@ nav.pagination {
         </div>
 		<p class="discreet" i18n:translate="help_keyword_assignments">
 		Select one or more keywords, then either
-		 set a replacement keyword and click on 'Merge / Replace' to replace all selected value by this one.
+		 set a replacement keyword and click on 'Rename' to replace all selected value by this one.
 		 Click on Delete to remove selected values.
 		</p>
 

--- a/src/Products/PloneKeywordManager/browser/prefs_keywords_view.py
+++ b/src/Products/PloneKeywordManager/browser/prefs_keywords_view.py
@@ -158,7 +158,7 @@ class PrefsKeywordsView(BrowserView):
         """
         if message and msg_type:
             pu = getToolByName(self.context, "plone_utils")
-            pu.addPortalMessage(safe_encode(message), type=msg_type)
+            pu.addPortalMessage(message, type=msg_type)
 
         logger.info(safe_encode(message))
         portal_url = self.context.portal_url()

--- a/src/Products/PloneKeywordManager/browser/prefs_keywords_view.py
+++ b/src/Products/PloneKeywordManager/browser/prefs_keywords_view.py
@@ -160,7 +160,7 @@ class PrefsKeywordsView(BrowserView):
             pu = getToolByName(self.context, "plone_utils")
             pu.addPortalMessage(message, type=msg_type)
 
-        logger.info(safe_encode(message))
+        logger.info(self.context.translate(message))
         portal_url = self.context.portal_url()
         url = "%s/prefs_keywords_view" % portal_url
         if field:


### PR DESCRIPTION
#53 

I'm being a bit rude here.   Issue #32 is only happening on Python 2.7 - I think.  I haven't done a py27 build to verify.

Unfortunately, simply rolling back @jensens change https://github.com/collective/Products.PloneKeywordManager/commit/6e9cb7adc853fe8c03f1d3f6467e9e5e05f8f476 and https://github.com/collective/Products.PloneKeywordManager/commit/1b3434972d74edc0e74c4a5dce953b843f018e73  makes the portalstatusmessages work just fine, with unicode.

The fix for #53 should be applied to a python2.7 release only.